### PR TITLE
Dependabot + Terraform ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       include: "scope"
   reviewers:
     - "cujarrett"
+- package-ecosystem: terraform
+  directory: "/terraform"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Hi @cujarrett,

Dependabot supports the Terraform ecosystem, in case this is of interest? It will keep the Terraform providers up-to-date.